### PR TITLE
Add check for min_gap to be at least 4 hours in rain_events

### DIFF
--- a/idf_analysis/event_series_analysis.py
+++ b/idf_analysis/event_series_analysis.py
@@ -173,8 +173,12 @@ def calculate_u_w(file_input, duration_steps, series_kind):
         # events[COL.rolling_sum_valuesAX_OVERLAPPING_SUM] = agg_events(events, roll_sum, 'max') * improve
         rolling_sum_values = agg_events(events, roll_sum, 'max') * improve
 
+        year_list = []
+        for e in events[COL.START]:
+            year_list.append(e.year)
+
         if series_kind == ANNUAL:
-            interim_results[duration_integer] = annual_series(rolling_sum_values, events[COL.START].year.values)
+            interim_results[duration_integer] = annual_series(rolling_sum_values, year_list)
         elif series_kind == PARTIAL:
             interim_results[duration_integer] = partial_series(rolling_sum_values, measurement_period)
         else:

--- a/idf_analysis/sww_utils.py
+++ b/idf_analysis/sww_utils.py
@@ -123,6 +123,11 @@ def rain_events(series, ignore_rain_below=0, min_gap=pd.Timedelta(hours=4)):
     Returns:
         pandas.DataFrame: table of the rain events
     """
+
+    # According to DWA A-531 Chapter 4.2, events should be atleast
+    # 4 hours apart to be statistically indepedent of each other
+    if min_gap < pd.Timedelta(hours=4):
+        min_gap = pd.Timedelta(hours=4)
     # best OKOSTRA adjustment with 0.0
     # by ignoring 0.1 mm the results are getting bigger
 


### PR DESCRIPTION
According to the DWA A-531 Chapter 4.2, rain events should be at least 4 hours apart to be statistically independent. This period is defined as the default parameter in the rain_events function. However, during function calls in e.g. calculate_u_uw() smaller gap periods are used. Therefore a new check is added, such that even if the method is called with a min_gap < 4 hours, it still will be at least 4 hours.