### PR TITLE
Solve 2 small issues

### DIFF
--- a/idf_analysis/event_series_analysis.py
+++ b/idf_analysis/event_series_analysis.py
@@ -69,7 +69,7 @@ def partial_series(rolling_sum_values, measurement_period):
     # use only the (2-3 multiplied with the number of measuring years) of the biggest
     # values in the database (-> acc. to ATV-A 121 chap. 4.3; DWA-A 531 chap. 4.4)
     # as an requirement for the extreme value distribution
-    threshold_sample_size = int(floor(measurement_period * e))
+    threshold_sample_size = int(min(floor(measurement_period * e), len(partially_series)))
     partially_series = partially_series[:threshold_sample_size]
 
     sample_size = threshold_sample_size

--- a/idf_analysis/idf_backend.py
+++ b/idf_analysis/idf_backend.py
@@ -222,7 +222,7 @@ class IdfParameters:
                          data=interim_results['u'] + interim_results['w'] * np.log(return_periods))
 
     def get_duration_section(self, duration, param):
-        for lower, upper in self._iter_params():
+        for lower, upper in reversed(list(self._iter_params())):
             if lower <= duration <= upper:
                 return self.parameters_final[lower][param]
 


### PR DESCRIPTION
Hi,

Thanks for the great library! I used it to do IDF analysis and I ran into 2 small issues:

**Error during parameter calculation**
When the duration is large, `partially_series` sometimes has less values than the `threshold_sample_size`. This raises an error because `log_return_periods` will then have more values than `partially_series` in this line:
```
_lin_regress(log_return_periods, partially_series)
```
The change I made reduce the size of log_return_periods to the same size as partially_series.

**No results for duration 60**
When the rainfall data is available per 60 minutes, the parameters_final for `0` will be `nan`. For `60` there will be parameters, but they are not used to calculate rainfall because the `0 <= 60.0 <= 60 ` is already true.

The change I made reverses the order in which the lower and upper bounds are checked, so that for values that exactly match a bound it the upper parameter set will be used.

Do you think these changes are ok and can be included in the next release?